### PR TITLE
Updating to 3.2.0rc

### DIFF
--- a/docker_builds/generic-dockerhub/16.04_3.2.0rc.yml
+++ b/docker_builds/generic-dockerhub/16.04_3.2.0rc.yml
@@ -1,0 +1,31 @@
+---
+  opensrf_git_branch: osrf_rel_3_0_1
+  evergreen_git_branch: tags/rel_3_2_rc1
+# This directory will be linked to /openilspath/var/web/.well-known
+  lets_encrypt_shared_web_folder: /mnt/evergreen/letsencrypt_shared_web_directory/.well-known
+  shared_reports_folder: /mnt/evergreen/reports
+  shared_circ_notices_folder: /mnt/evergreen/circ_notices
+  sync_openils_sub_folders_cmd: /mnt/evergreen/apps/syncop
+  ejabberd_password: ejabberdpassword
+  os_user_password: password
+  openils_path: /openils
+  evergreen_stamp_id: rel_3_0_3
+  domain_name: localhost
+  database_host: 127.0.0.1
+  database_database: evergreen
+  database_port: 5432
+  database_user: evergreen
+  database_password: databasepassword
+  evergreen_global_admin: admin
+  evergreen_global_admin_password: demo123
+  sender_address: no-reply@localhost.com
+  base_reporter_uri: https://localhost/reporter/
+  reporter_output_folder: /openils/var/web/reporter
+  opensrf_zip_file_line: <zips_file>/openils/conf/zips.txt</zips_file>
+  opensrf_memcached_server: 127.0.0.1
+  opensrf_memcached_port: 11211
+  use_custom_opensrf_xml: no
+  Evergreen_cherry_picks: []
+  OpenSRF_cherry_picks: []
+  SIPServer_cherry_picks: []
+...

--- a/docker_builds/generic-dockerhub/Dockerfile
+++ b/docker_builds/generic-dockerhub/Dockerfile
@@ -18,6 +18,7 @@ RUN mkdir -p /mnt/evergreen
 
 # Run dockerbase script
 ADD     syslog-ng.sh /egconfigs/
+RUN     chmod +x /egconfigs/syslog-ng.sh
 RUN     /egconfigs/syslog-ng.sh
 
 # Add syslog-ng into runit
@@ -34,7 +35,7 @@ ADD hosts /egconfigs/hosts
 ADD ejabberd.yml /egconfigs/ejabberd.yml
 ADD logrotate_evergreen.txt /egconfigs/logrotate_evergreen.txt
 
-ADD 16.04_3.0.0.yml /egconfigs/16.04_3.0.0.yml
+ADD 16.04_3.2.0rc.yml /egconfigs/16.04_3.2.0rc.yml
 ADD install_evergreen.yml /egconfigs/install_evergreen.yml
 ADD evergreen_restart_services.yml /egconfigs/evergreen_restart_services.yml
 RUN cd /egconfigs && ansible-playbook install_evergreen.yml -v -e "hosts=127.0.0.1"

--- a/docker_builds/generic-dockerhub/evergreen_restart_services.yml
+++ b/docker_builds/generic-dockerhub/evergreen_restart_services.yml
@@ -5,7 +5,7 @@
   remote_user: user
   become_method: sudo
   vars_files:
-    - 16.04_3.0.0.yml
+    - 16.04_3.2.0rc.yml
   tasks:
   - name: Setup host file
     become: true

--- a/docker_builds/generic-dockerhub/install_evergreen.yml
+++ b/docker_builds/generic-dockerhub/install_evergreen.yml
@@ -6,7 +6,7 @@
   remote_user: user
   become_method: sudo
   vars_files:
-    - 16.04_3.0.0.yml
+    - 16.04_3.2.0rc.yml
   tasks:
   - name: starting ssh
     service:
@@ -266,17 +266,21 @@
     become: true
     become_user: opensrf
     shell: cd /home/opensrf/repos/Evergreen && autoreconf -i
-  - name: Setting up npm and grunt
+  - name: Setting up npm
     become: true
     become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/web/js/ui/default/staff/ && npm install && grunt all
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/web/js/ui/default/staff/ && npm install && npm run build-prod && npm run test
+  - name: Setting up eg2
+    become: true
+    become_user: opensrf
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/ && npm install && npm run build --prod && npm run test
   - name: Configuring Evergreen code and make
     become: true
     become_user: opensrf
     shell: cd /home/opensrf/repos/Evergreen && PATH={{openils_path}}/bin:$PATH ./configure --prefix={{openils_path}} --sysconfdir={{openils_path}}/conf && make
   - name: Install Evergreen
     become: true
-    shell: cd /home/opensrf/repos/Evergreen && make STAFF_CLIENT_STAMP_ID={{evergreen_stamp_id}} install
+    shell: cd /home/opensrf/repos/Evergreen && make install
   - file: path={{openils_path}}/var/web/xul/server state=absent
   - name: Setup Symlink {{openils_path}}/var/web/xul/server
     become: true
@@ -287,7 +291,7 @@
     shell: cd /home/opensrf && wget http://download.dojotoolkit.org/release-1.3.3/dojo-release-1.3.3.tar.gz && tar -C {{openils_path}}/var/web/js -xzf dojo-release-1.3.3.tar.gz && cp -r {{openils_path}}/var/web/js/dojo-release-1.3.3/* {{openils_path}}/var/web/js/dojo/.
   - name: Copy default Evergreen apache configs
     become: true
-    shell: cd /home/opensrf/repos/Evergreen && cp Open-ILS/examples/apache_24/eg_24.conf /etc/apache2/sites-available/eg.conf && cp Open-ILS/examples/apache_24/eg_vhost_24.conf /etc/apache2/eg_vhost.conf && cp Open-ILS/examples/apache/eg_startup /etc/apache2/
+    shell: cd /home/opensrf/repos/Evergreen && cp Open-ILS/examples/apache_24/eg_24.conf /etc/apache2/sites-available/eg.conf && cp Open-ILS/examples/apache_24/eg_vhost_24.conf /etc/apache2/eg_vhost.conf && cp Open-ILS/examples/apache_24/eg_startup /etc/apache2/
   - file: path=/etc/apache2/ssl state=directory
   - name: Setup SSL Certs
     become: true
@@ -440,15 +444,6 @@
     apt: name=nsis
   - name: Install zip
     apt: name=zip
-  - name: Remove xul/server links
-    become: true
-    shell: rm {{openils_path}}/var/web/xul/server
-  - name: Compile xul staff client
-    become: true
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/xul/staff_client && make clean && make AUTOUPDATE_HOST={{domain_name}} STAFF_CLIENT_STAMP_ID={{evergreen_stamp_id}} STAFF_CLIENT_BUILD_ID={{evergreen_stamp_id}} rigrelease install && make updates-client
-  - name: Setup Symlink {{openils_path}}/var/web/xul/server
-    become: true
-    shell: cd {{openils_path}}/var/web/xul && ln -sf {{evergreen_stamp_id}}/server server && chown -R opensrf:opensrf {{openils_path}}
   - name: Make opensrf the owner
     become: true
     shell: chown -R opensrf:opensrf /home/opensrf/repos


### PR DESCRIPTION
Wasn't sure if you're interested in pull requests, but if so, this worked for me to create docker images for the 3.2 release candidate.  I just ran `docker build --tag [name_of_tag] . ` in the docker_builds/generic-dockerhub directory; haven't done any other testing.