### PR TITLE
Install Evergreen 3.6

### DIFF
--- a/docker_builds/generic-dockerhub/16.04_3.2.x.yml
+++ b/docker_builds/generic-dockerhub/16.04_3.2.x.yml
@@ -1,6 +1,6 @@
 ---
-  opensrf_git_branch: osrf_rel_3_2_0
-  evergreen_git_branch: tags/rel_3_4_0
+  opensrf_git_branch: osrf_rel_3_2_1
+  evergreen_git_branch: tags/rel_3_6_1
 # This directory will be linked to /openilspath/var/web/.well-known
   lets_encrypt_shared_web_folder: /mnt/evergreen/letsencrypt_shared_web_directory/.well-known
   shared_reports_folder: /mnt/evergreen/reports

--- a/docker_builds/generic-dockerhub/install_evergreen_pre36.yml
+++ b/docker_builds/generic-dockerhub/install_evergreen_pre36.yml
@@ -270,22 +270,10 @@
     become: true
     become_user: opensrf
     shell: cd /home/opensrf/repos/Evergreen/Open-ILS/web/js/ui/default/staff/ && npm install && npm run build-prod && npm run test
-    environment:
-      CHROME_BIN: /usr/bin/chromium-browser
-  - name: Setting up bootstrap opac
-    become: true
-    become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/web/opac/deps/ && npm install
-  - name: Opt out of Chrome eg2 testing
-    lineinfile:
-      dest: /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/karma.conf.js
-      state: present
-      regexp: ChromeHeadless
-      line: "    browsers: ['FirefoxHeadless'],"
   - name: Setting up eg2
     become: true
     become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/ && npm install && ng build --prod && npm run test
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/ && npm install && npm run build --prod && npm run test
   - name: Configuring Evergreen code and make
     become: true
     become_user: opensrf


### PR DESCRIPTION
Runs npm for the new bootstrap OPAC, and turns off headless Chrome testing for angular (due to various issues running headless Chrome in docker with x11 and sandboxing).