### PR TITLE
Use the correct ng build command depending on evergreen version

### DIFF
--- a/generic-dockerhub/install_evergreen.yml
+++ b/generic-dockerhub/install_evergreen.yml
@@ -446,7 +446,7 @@
   - name: Setting up eg2 for EG version 3.2 and above
     become: true
     become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/ && npm install && ng build --prod
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/ && npm install && {{ angular_build_command }}
     when: evergreen_major_version|int > 2 and evergreen_minor_version|int > 1
 
   - name: Setting up bootstrap opac for EG 3.6 and above

--- a/generic-dockerhub/vars.yml
+++ b/generic-dockerhub/vars.yml
@@ -18,6 +18,7 @@
   install_xul_client: "{% if (evergreen_major_version|int > 2 and evergreen_minor_version|int < 3) or evergreen_major_version|int == 2 %}yes{% else %}no{% endif %}"
   evergreen_stamp_id: "{{ 'rel_' + (evergreen_version|regex_replace('\\.', '_')) }}"
   postgres_version: "{% if ubuntu_version|lower == 'jammy' or ubuntu_version|lower == 'focal' %}10{% elif ubuntu_version|lower == 'bionic' %}9.6{% else %}9.5{% endif %}"
+  angular_build_command: "ng build {% if (evergreen_major_version|int == 3 and evergreen_minor_version|int < 9) %}--prod{% else %}--configuration=production{% endif %}"
 
 # The latest version of OpenSRF seems to work with all versions of Evergreen.
   opensrf_git_branch: osrf_rel_3_2_2


### PR DESCRIPTION
With Evergreen 3.11 (running angular 15), the `ng build --prod` option is no longer available.  It was deprecated back in Evergreen 3.9 (angular 12) in favor of `ng build --configuration=production`.