### PR TITLE
Install the appropriate version of websocketd according to the container's architecture

### DIFF
--- a/generic-dockerhub/install_evergreen.yml
+++ b/generic-dockerhub/install_evergreen.yml
@@ -244,11 +244,11 @@
 
   - name: Download websocketsd
     become: true
-    shell: cd /tmp && wget 'https://github.com/joewalnes/websocketd/releases/download/v0.3.0/websocketd-0.3.0-linux_amd64.zip'
+    shell: "cd /tmp && wget https://github.com/joewalnes/websocketd/releases/download/v{{ websocketd_version }}/{{ websocketd_filename }}"
 
   - name: Unzip Websockets
     become: true
-    shell: cd /tmp && unzip -u websocketd-0.3.0-linux_amd64.zip && cp websocketd /usr/local/bin/
+    shell: "cd /tmp && unzip -u {{ websocketd_filename }} && cp websocketd /usr/local/bin/"
 
 # # ### OPENSRF IS FINISHED
 

--- a/generic-dockerhub/vars.yml
+++ b/generic-dockerhub/vars.yml
@@ -18,6 +18,8 @@
   install_xul_client: "{% if (evergreen_major_version|int > 2 and evergreen_minor_version|int < 3) or evergreen_major_version|int == 2 %}yes{% else %}no{% endif %}"
   evergreen_stamp_id: "{{ 'rel_' + (evergreen_version|regex_replace('\\.', '_')) }}"
   postgres_version: "{% if ubuntu_version|lower == 'jammy' or ubuntu_version|lower == 'focal' %}10{% elif ubuntu_version|lower == 'bionic' %}9.6{% else %}9.5{% endif %}"
+  websocketd_version: 0.3.0
+  websocketd_filename: "websocketd-{{ websocketd_version }}-linux_{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}.zip"
 
 # The latest version of OpenSRF seems to work with all versions of Evergreen.
   opensrf_git_branch: osrf_rel_3_2_2


### PR DESCRIPTION
Download the arm64 version of websocketd if ansible knows that it's running on an arm64 container, otherwise default to amd64.

Closes #7 