### PR TITLE
[generic dockerhub images] allow pgtap installation to find the correct pg_config for the desired postgres version

### DIFF
--- a/generic-dockerhub-dev-redis/install_evergreen.yml
+++ b/generic-dockerhub-dev-redis/install_evergreen.yml
@@ -853,6 +853,8 @@
     shell: cd ~postgres/pgtap-1.1.0 && make install && cpan TAP::Parser::SourceHandler::pgTAP
     ignore_errors: yes
     when: install_pg_tap|bool == true
+    environment:
+      PG_CONFIG: "/usr/lib/postgresql/{{ postgres_version }}/bin/pg_config"
   - name: Add pgtap extension
     become: true
     become_user: postgres

--- a/generic-dockerhub-dev/install_evergreen.yml
+++ b/generic-dockerhub-dev/install_evergreen.yml
@@ -801,6 +801,8 @@
     shell: cd ~postgres/pgtap-1.1.0 && make install && cpan TAP::Parser::SourceHandler::pgTAP
     ignore_errors: yes
     when: install_pg_tap|bool == true
+    environment:
+      PG_CONFIG: "/usr/lib/postgresql/{{ postgres_version }}/bin/pg_config"
   - name: Add pgtap extension
     become: true
     become_user: postgres

--- a/generic-dockerhub/install_evergreen.yml
+++ b/generic-dockerhub/install_evergreen.yml
@@ -837,6 +837,8 @@
     shell: cd ~postgres/pgtap-1.1.0 && make install && cpan TAP::Parser::SourceHandler::pgTAP
     ignore_errors: yes
     when: install_pg_tap|bool == true
+    environment:
+      PG_CONFIG: "/usr/lib/postgresql/{{ postgres_version }}/bin/pg_config"
   - name: Add pgtap extension
     become: true
     become_user: postgres


### PR DESCRIPTION
Otherwise, it may not be able to find the correct postgres binaries and fail to install correctly.