### PR TITLE
Tests on dev container

### DIFF
--- a/generic-dockerhub-dev/evergreen_restart_services.yml
+++ b/generic-dockerhub-dev/evergreen_restart_services.yml
@@ -571,6 +571,16 @@
                       ansible-playbook /egconfigs/restart_post_boot.yml -v -e "hosts=127.0.0.1" &> "$CHECKFILE"_screenoutput
                   fi
 
+                  CHECKFILE=/home/opensrf/repos/Evergreen/eg_run_tests
+                  if test -f "$CHECKFILE"; then
+                      TEST_TAGS=$(cat $CHECKFILE)
+                      if [ -n "$TEST_TAGS" ]; then
+                          TEST_TAGS="-t $TEST_TAGS"
+                      fi
+                      rm $CHECKFILE
+                      ansible-playbook /egconfigs/run_tests.yml $TEST_TAGS -v  &> "$CHECKFILE"_screenoutput
+                  fi
+
                   CHECKFILE=/home/opensrf/repos/Evergreen/db_switch_LOCK
                   if [ ! -f "$CHECKFILE" ]; then
                       /egconfigs/db_switcher.pl >>/home/opensrf/repos/Evergreen/db_switch.log 2>&1

--- a/generic-dockerhub-dev/install_evergreen.yml
+++ b/generic-dockerhub-dev/install_evergreen.yml
@@ -929,4 +929,11 @@
     become: true
     when: install_rust|bool == true
     shell: cd /home/opensrf/repos/evergreen-universe-rs && make install-bin
+  - name: allow opensrf to psql without password
+    become: true
+    become_user: opensrf
+    copy:
+      mode: '0600'
+      dest: "/home/opensrf/.pgpass"
+      content: "{{ database_host }}:{{ database_port }}:{{ database_database }}:{{ database_user }}:{{ database_password }}"
 ...

--- a/generic-dockerhub-dev/run_tests.yml
+++ b/generic-dockerhub-dev/run_tests.yml
@@ -13,23 +13,37 @@
     environment:
       PATH: "{{ ansible_env.PATH }}:{{openils_path}}/bin"
     shell: export PATH=$PATH:{{openils_path}}/bin && {{openils_path}}/bin/osrf_control --localhost --stop-all
-    tags: perl,angular,pgtap
+    tags: angular,pgtap
   - name: Setup | Reload a fresh copy of the concerto dataset
     become: true
     shell: cd /home/opensrf/repos/Evergreen && perl Open-ILS/src/support-scripts/eg_db_config --update-config --service all --create-database --create-schema --create-offline --user {{ database_user }} --password {{ database_password }} --hostname {{ database_host }} --port {{ database_port }} --database {{ database_database }} --admin-user {{ evergreen_global_admin }} --admin-pass {{ evergreen_global_admin_password }} --load-all-sample
-    tags: perl,angular,pgtap
+    tags: angular,pgtap
   - name: Setup | Start OpenSRF
     become: true
     become_user: opensrf
     environment:
       PATH: "{{ ansible_env.PATH }}:{{openils_path}}/bin"
     shell: export PATH=$PATH:{{openils_path}}/bin && {{openils_path}}/bin/osrf_control --localhost --start-all
-    tags: perl,angular,pgtap
+    tags: angular,pgtap
   - name: Setup | Install Firefox
     become: true
     apt:
-      name: firefox
+      name: firefox-nightly
+      update_cache: true
     tags: angularjs,angular,opac
+  - name: Setup | Symlink firefox to the firefox-nightly we got from mozilla
+    become: true
+    file:
+      state: link
+      src: /usr/bin/firefox-nightly
+      dest: /usr/bin/firefox
+    tags: angularjs,angular,opac
+  - name: Setup | Give evergreen user access to opensrf directories
+    user:
+      name: evergreen
+      groups: opensrf
+      append: yes
+    tags: pgtap
   - name: Setup | Activate pgtap extension
     become: true
     become_user: evergreen
@@ -55,14 +69,12 @@
     tags: pgtap
   - name: Test | Run AngularJS unit tests
     become: true
-    become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/web/js/ui/default/staff && npm run test
+    shell: cd /home/opensrf/repos/Evergreen-build/Open-ILS/web/js/ui/default/staff && npm run test
     ignore_errors: true
     tags: angularjs
   - name: Test | Run Angular unit tests
     become: true
-    become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2 && npm run test
+    shell: cd /home/opensrf/repos/Evergreen-build/Open-ILS/src/eg2 && npm run test
     ignore_errors: true
     tags: angular
   - name: Test | Run Angular e2e tests
@@ -76,25 +88,40 @@
   - name: Test | Run OPAC js unit tests
     become: true
     become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/web/opac/deps && npm run test
+    shell: cd /home/opensrf/repos/Evergreen-build/Open-ILS/web/opac/deps && npm run test
     ignore_errors: true
     tags: opac
-  - name: Test | Run Perl unit tests
+  - name: Perl Live Test Setup | Stop OpenSRF
     become: true
     become_user: opensrf
+    environment:
+      PATH: "{{ ansible_env.PATH }}:{{openils_path}}/bin"
+    shell: export PATH=$PATH:{{openils_path}}/bin && {{openils_path}}/bin/osrf_control --localhost --stop-all
+    tags: perl
+  - name: Perl Live Test Setup | Reload a fresh copy of the concerto dataset
+    become: true
+    shell: cd /home/opensrf/repos/Evergreen && perl Open-ILS/src/support-scripts/eg_db_config --update-config --service all --create-database --create-schema --create-offline --user {{ database_user }} --password {{ database_password }} --hostname {{ database_host }} --port {{ database_port }} --database {{ database_database }} --admin-user {{ evergreen_global_admin }} --admin-pass {{ evergreen_global_admin_password }} --load-all-sample
+    tags: perl
+  - name: Perl Live Test Setup | Start OpenSRF
+    become: true
+    become_user: opensrf
+    environment:
+      PATH: "{{ ansible_env.PATH }}:{{openils_path}}/bin"
+    shell: export PATH=$PATH:{{openils_path}}/bin && {{openils_path}}/bin/osrf_control --localhost --start-all
+    tags: perl
+  - name: Test | Run Perl unit tests
+    become: true
     shell: cd /home/opensrf/repos/Evergreen && make check
     ignore_errors: true
     tags: perl
   - name: Test | Run Perl live tests
     become: true
-    become_user: opensrf
     shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/perlmods && make livecheck
     ignore_errors: true
     tags: perl
   - name: Test | Run C unit tests
     become: true
-    become_user: opensrf
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/c-apps/tests && make check
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/c-apps && make check
     ignore_errors: true
     tags: c
   - name: Teardown | Stop OpenSRF


### PR DESCRIPTION
This makes running tests in the dev container a bit more pleasant in a few ways:

- You can now run tests from your host machine, rather than needing to shell into the container:
    ```
    touch eg_run_tests # runs all tests and adds the results to eg_run_tests_screenoutput
    echo "angular" > eg_run_tests # just runs the angular tests, logs the results to eg_run_tests_screenoutput
    echo "angularjs" > eg_run_tests # just runs the angular tests, logs the results to eg_run_tests_screenoutput
    echo "c" > eg_run_tests # just runs the c tests, logs the results to eg_run_tests_screenoutput
    echo "opac" > eg_run_tests # just runs the opac tests
    echo "perl" > eg_run_tests # just runs the perl tests
    echo "pgtap" > eg_run_tests # just runs the pgtap tests
    echo "angularjs,c,pgtap" > eg_run_tests # runs the angularjs, c, and pgtap tests
    ```
- If you are still in the habit of shelling into the container (for example, me hahaha), this makes running pg_tap tests as the opensrf user more pleasant by adding a `.pgpass` file.  Now, opensrf can run `psql -U evergreen -h localhost` or `pg_prove -U evergreen -h localhost`, and postgress will not prompt for a password
- Some tests were not passing when run from the `run_tests.yml` ansible playbook within the dev container.  This gets more of those passing by dealing with some permissions issues (the dev container requires some of these to be run as root) and by running some from within the `rsync`ed Evergreen-build directory.