### PR TITLE
Add an ansible playbook for pl/pgsql performance profiling

### DIFF
--- a/generic-dockerhub-dev/Dockerfile
+++ b/generic-dockerhub-dev/Dockerfile
@@ -53,6 +53,7 @@ ADD install_evergreen.yml /egconfigs/install_evergreen.yml
 ADD evergreen_restart_services.yml /egconfigs/evergreen_restart_services.yml
 ADD restart_post_boot.yml /egconfigs/restart_post_boot.yml
 ADD run_tests.yml /egconfigs/run_tests.yml
+ADD plprofiler.yml /egconfigs/plprofiler.yml
 RUN cd /egconfigs && ansible-playbook install_evergreen.yml -v
 ENTRYPOINT cd /egconfigs && ansible-playbook evergreen_restart_services.yml -vvvv && while true; do sleep 1; done
 #ENTRYPOINT while true; do sleep 1; done

--- a/generic-dockerhub-dev/plprofiler.yml
+++ b/generic-dockerhub-dev/plprofiler.yml
@@ -1,0 +1,58 @@
+---
+# A playbook that you can use to performance profile a single pl/pgsql function
+# 
+# Usage:
+# ansible-playbook /egconfigs/plprofiler.yml -e="command='SELECT * FROM asset.opac_ou_record_copy_count(7, 244)'" -e iterations=500
+# ansible-playbook /egconfigs/plprofiler.yml -e="command='SELECT unapi.memoize( \'bre\', 1,\'mods32\',\'\',\'{holdings_xml,acp}\'::TEXT[], \'SYS1\')'" # note that the single quotes in your query need to be escaped
+#
+# You can then ls /home/evergreen/profile* and docker cp the profile file to your host machine,
+# then open it in your favorite browser
+
+- hosts: localhost
+  connection: local
+  remote_user: user
+  become_method: sudo
+  vars:
+    command: "SELECT unapi.bre(216,'holdings_xml','record','{}'::TEXT[], 'BR1')"
+    iterations: 100
+  vars_files:
+    - vars.yml
+  tasks:
+  - name: Install | install pip
+    become: true
+    apt:
+      name: python3-pip
+  - name: Install | install client
+    become: true
+    environment:
+      PATH: "/usr/lib/postgresql/{{ postgres_version }}/bin:{{ lookup('env', 'PATH') }}"
+    pip:
+      name:
+        - plprofiler-client
+        - psycopg2-binary
+  - name: Install | clone repo
+    become: true
+    become_user: opensrf
+    git:
+      repo: 'https://github.com/bigsql/plprofiler.git'
+      dest: /home/opensrf/repos/plprofiler
+  - name: Install | make install
+    become: true
+    environment:
+      USE_PGXS: 1
+      PATH: "/usr/lib/postgresql/{{ postgres_version }}/bin:{{ lookup('env', 'PATH') }}"
+    shell: 
+      cmd: make install
+      chdir: /home/opensrf/repos/plprofiler
+  - name: Install | Create extension
+    become: true
+    become_user: evergreen
+    shell: 'psql -c "CREATE EXTENSION IF NOT EXISTS plprofiler"'
+  - name: Profile | Profile command
+    become: true
+    become_user: evergreen
+    shell:
+      cmd: >
+            plprofiler run --command "{% for number in range(0, iterations|int) %}{{ command }};{% endfor %}" --output="profile-$(date +'%Y-%m-%d:%H:%M:%S')" --name="My profile" --title="My profile" --desc="Profile"
+      chdir: /home/evergreen
+...


### PR DESCRIPTION
This playbook allows you to performance profile a single pl/pgsql function and see what its performance bottlenecks may be.  It produces an HTML report that you can then `docker/podman cp` to your host computer to view in a browser.

It uses the very nice [plprofiler tool](https://github.com/bigsql/plprofiler)

@bmagic007 I wanted your thoughts on including it -- it is useful only for specific kinds of work (i.e. when you are in the weeds on a pl/pgsql function), and doesn't fit into the current infrastructure where you can touch a file from the container host (although I could add that if desired).  But it has been pretty useful for me today while I'm in those weeds, so I wanted to share it for consideration.