### PR TITLE
feat: shrink image by 1.4 GB

### DIFF
--- a/generic-dockerhub/Dockerfile
+++ b/generic-dockerhub/Dockerfile
@@ -55,6 +55,6 @@ ADD install_evergreen.yml /egconfigs/install_evergreen.yml
 ADD evergreen_restart_services.yml /egconfigs/evergreen_restart_services.yml
 ADD restart_post_boot.yml /egconfigs/restart_post_boot.yml
 ADD run_tests.yml /egconfigs/run_tests.yml
-RUN cd /egconfigs && ansible-playbook install_evergreen.yml -v
+RUN cd /egconfigs && ansible-playbook install_evergreen.yml -v && rm -rf /home/opensrf/repos /home/opensrf/*.tar.gz
 ENTRYPOINT cd /egconfigs && ansible-playbook evergreen_restart_services.yml -vvvv && while true; do sleep 1; done
 #ENTRYPOINT while true; do sleep 1; done

--- a/generic-tarball/Dockerfile
+++ b/generic-tarball/Dockerfile
@@ -56,6 +56,6 @@ ADD evergreen_restart_services.yml /egconfigs/evergreen_restart_services.yml
 ADD restart_post_boot.yml /egconfigs/restart_post_boot.yml
 ADD run_tests.yml /egconfigs/run_tests.yml
 
-RUN cd /egconfigs && ansible-playbook install_evergreen.yml -v
+RUN cd /egconfigs && ansible-playbook install_evergreen.yml -v && rm -rf /home/opensrf/repos /home/opensrf/*.tar.gz
 ENTRYPOINT cd /egconfigs && ansible-playbook evergreen_restart_services.yml -vvvv && while true; do sleep 1; done
 #ENTRYPOINT while true; do sleep 1; done


### PR DESCRIPTION
### Summary

Shrink the generic-dockerhub and generic-tarball images by removing the Git repos in the last layer.

### Details

Using [dive](https://github.com/wagoodman/dive), I analyzed the layers in the images created by generic-dockerhub/Dockerfile and generic-tarball/Dockerfile.  The final layer of these images (created by `ansible-playbook install_evergreen.yml`) was by far the largest at 4.6 GB.  Much of this was in the source/git tree, which is not needed after the build is done.

I did not evaluate generic-dockerhub-dev; I don't use that one, and removing sources does not seem applicable there.

### Further Work

These Dockerfiles are not very "dockerish" in that they bundle many services into one image.  I do appreciate that these probably grew organically from a working ansible install, they are very useful as-is, and more useful being smaller.

It would be possible to completely reorient this into a Compose stack, where instead of installing Postgres and ejabberd we compose those from separate optimized images.  It would also be possible to use [multi-stage builds](https://docs.docker.com/build/building/multi-stage/), installing the prerequisites into a builder image, and copying only the required binaries into the final image.  Both of those are significantly more work.  If there is an audience for those, I will consider it.
