### PR TITLE
[dev image] Don't overwrite entityized fm_IDL.xml file when translation support is on

### DIFF
--- a/generic-dockerhub-dev/evergreen_restart_services.yml
+++ b/generic-dockerhub-dev/evergreen_restart_services.yml
@@ -423,6 +423,13 @@
     become: true
     become_user: opensrf
     shell: cp {{ openils_path }}/conf/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml
+    when: add_evergreen_language_support|bool == false
+
+  - name: Copy localized fm_IDL
+    become: true
+    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml
+    when: add_evergreen_language_support|bool == true
+
   - name: Start Web services
     ignore_errors: yes
     become: true

--- a/generic-dockerhub-dev/restart_post_boot.yml
+++ b/generic-dockerhub-dev/restart_post_boot.yml
@@ -122,6 +122,12 @@
       mode: 0644
       src: /home/opensrf/repos/Evergreen/Open-ILS/examples/fm_IDL.xml
       dest: /openils/var/web/reports/fm_IDL.xml
+    when: add_evergreen_language_support|bool == false
+
+  - name: Put the localized fm_IDL.xml in reports folder
+    become: true
+    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml
+    when: add_evergreen_language_support|bool == true
 
   - name: Autoreconf
     become: true


### PR DESCRIPTION
`cd build/i18n && make install` creates a very specific version of the fm_IDL.xml file at Open-ILS/web/reports/fm_IDL.xml.  This version has a special `#include virtual` doodad that allows it to pull in translations, and placeholders for the translated strings to go into.  The code refers to this as an "entityized" file.

The project's `make install` process will install this into place at /openils/var/web/reports/fm_IDL.xml, where it can be used to provide translated names of fields and tables.

However, prior to this commit, both the evergreen_restart_services and restart_post_boot playbooks subsequently copied
/openils/conf/fm_IDL.xml on top of the reports fm_IDL.xml, losing the ability for Evergreen to provide the translated fields and tables.

This commit updates both playbooks to instead, if language support is turned on, regenerate the entityized fm_IDL.xml to catch any hot new updates that the developer has made locally and copy it into place in /openils/var/web/reports.