### PR TITLE
Copy IDL dtd file into place

### DIFF
--- a/generic-dockerhub-dev/evergreen_restart_services.yml
+++ b/generic-dockerhub-dev/evergreen_restart_services.yml
@@ -427,7 +427,7 @@
 
   - name: Copy localized fm_IDL
     become: true
-    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml
+    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml && cp -R /home/opensrf/repos/Evergreen/Open-ILS/web/opac/locale {{ openils_path }}/var/web/opac/
     when: add_evergreen_language_support|bool == true
 
   - name: Start Web services

--- a/generic-dockerhub-dev/restart_post_boot.yml
+++ b/generic-dockerhub-dev/restart_post_boot.yml
@@ -126,7 +126,7 @@
 
   - name: Put the localized fm_IDL.xml in reports folder
     become: true
-    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml
+    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml && cp -R /home/opensrf/repos/Evergreen/Open-ILS/web/opac/locale {{ openils_path }}/var/web/opac/
     when: add_evergreen_language_support|bool == true
 
   - name: Autoreconf


### PR DESCRIPTION
To translate the IDL, the Makefile in build/i18n creates an "entityized" IDL xml file with no strings whatsoever, along with DTD files for each language that provide the necessary strings.

Pull request #39 added the ability to regenerate the entityized IDL and DTD files on each run of the
evergreen_restart_services or restart_post_boot playbooks. It even copied the entityized IDL xml file into place!  But it neglected to also copy the DTD files into place, which had the potential to cause Internal Server Errors when visiting /IDL2js.