### PR TITLE
[dev container] Run newpot when language support is true

### DIFF
--- a/generic-dockerhub-dev/evergreen_restart_services.yml
+++ b/generic-dockerhub-dev/evergreen_restart_services.yml
@@ -427,7 +427,7 @@
 
   - name: Copy localized fm_IDL
     become: true
-    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml && cp -R /home/opensrf/repos/Evergreen/Open-ILS/web/opac/locale {{ openils_path }}/var/web/opac/
+    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make newpot install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml && cp -R /home/opensrf/repos/Evergreen/Open-ILS/web/opac/locale {{ openils_path }}/var/web/opac/
     when: add_evergreen_language_support|bool == true
 
   - name: Start Web services

--- a/generic-dockerhub-dev/restart_post_boot.yml
+++ b/generic-dockerhub-dev/restart_post_boot.yml
@@ -126,7 +126,7 @@
 
   - name: Put the localized fm_IDL.xml in reports folder
     become: true
-    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml && cp -R /home/opensrf/repos/Evergreen/Open-ILS/web/opac/locale {{ openils_path }}/var/web/opac/
+    shell: cd /home/opensrf/repos/Evergreen/build/i18n && make newpot install && cp /home/opensrf/repos/Evergreen/Open-ILS/web/reports/fm_IDL.xml {{ openils_path }}/var/web/reports/fm_IDL.xml && chown opensrf:opensrf {{ openils_path }}/var/web/reports/fm_IDL.xml && cp -R /home/opensrf/repos/Evergreen/Open-ILS/web/opac/locale {{ openils_path }}/var/web/opac/
     when: add_evergreen_language_support|bool == true
 
   - name: Autoreconf


### PR DESCRIPTION
This avoids the following situation:

1. Developer adds a field to the IDL
2. Developer runs touch evergreen_restart_go on a dev container with language support enabled.
3. The restart_post_boot playbook runs, generating a new entityized IDL file and copying it (along with existing DTDs) into place.
4. The entityized IDL file references the entity for the new field, but the DTDs do not have the entity.  localhost/IDL2js returns a 500 Server Error.

newpot regenerates the DTDs, so we no longer experience the issue with DTDs missing new fields.