### PR TITLE
Run ng commands with npx prefix

### DIFF
--- a/generic-dockerhub-dev/run_tests.yml
+++ b/generic-dockerhub-dev/run_tests.yml
@@ -82,7 +82,7 @@
     become_user: opensrf
     environment:
       MOZ_HEADLESS: 1
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2 && ng e2e
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2 && npx ng e2e
     ignore_errors: true
     tags: angular,angular-e2e
   - name: Test | Run OPAC js unit tests

--- a/generic-dockerhub-dev/vars.yml
+++ b/generic-dockerhub-dev/vars.yml
@@ -20,7 +20,7 @@
   postgres_version: "{% if ubuntu_version|lower == 'jammy' or ubuntu_version|lower == 'focal' %}15{% elif ubuntu_version|lower == 'bionic' %}9.6{% else %}9.5{% endif %}"
   websocketd_version: 0.3.0
   websocketd_filename: "websocketd-{{ websocketd_version }}-linux_{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}.zip"
-  angular_build_command: "ng build {% if (evergreen_major_version|int == 3 and evergreen_minor_version|int < 9) %}--prod{% else %}--configuration=production{% endif %}"
+  angular_build_command: "npx ng build {% if (evergreen_major_version|int == 3 and evergreen_minor_version|int < 9) %}--prod{% else %}--configuration=production{% endif %}"
 
 # The latest version of OpenSRF seems to work with all versions of Evergreen.
   opensrf_git_branch: main

--- a/generic-dockerhub/run_tests.yml
+++ b/generic-dockerhub/run_tests.yml
@@ -84,7 +84,7 @@
     become_user: opensrf
     environment:
       MOZ_HEADLESS: 1
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2 && ng e2e
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2 && npx ng e2e
     ignore_errors: true
     tags: angular,angular-e2e
   - name: Test | Run OPAC js unit tests

--- a/generic-dockerhub/vars.yml
+++ b/generic-dockerhub/vars.yml
@@ -20,7 +20,7 @@
   postgres_version: "{% if evergreen_major_version|int == 3 and evergreen_minor_version|int > 13 %}15{% elif ubuntu_version|lower == 'jammy' or ubuntu_version|lower == 'focal' %}10{% elif ubuntu_version|lower == 'bionic' %}9.6{% else %}9.5{% endif %}"
   websocketd_version: 0.3.0
   websocketd_filename: "websocketd-{{ websocketd_version }}-linux_{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}.zip"
-  angular_build_command: "ng build {% if (evergreen_major_version|int == 3 and evergreen_minor_version|int < 9) %}--prod{% else %}--configuration=production{% endif %}"
+  angular_build_command: "npx ng build {% if (evergreen_major_version|int == 3 and evergreen_minor_version|int < 9) %}--prod{% else %}--configuration=production{% endif %}"
 
 # The latest version of OpenSRF seems to work with all versions of Evergreen.
   opensrf_git_branch: osrf_rel_3_3_2

--- a/generic-tarball/run_tests.yml
+++ b/generic-tarball/run_tests.yml
@@ -84,7 +84,7 @@
     become_user: opensrf
     environment:
       MOZ_HEADLESS: 1
-    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2 && ng e2e
+    shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/eg2 && npx ng e2e
     ignore_errors: true
     tags: angular,angular-e2e
   - name: Test | Run OPAC js unit tests

--- a/generic-tarball/vars.yml
+++ b/generic-tarball/vars.yml
@@ -20,7 +20,7 @@
   postgres_version: "{% if evergreen_major_version|int == 3 and evergreen_minor_version|int > 13 %}15{% elif ubuntu_version|lower == 'jammy' or ubuntu_version|lower == 'focal' %}10{% elif ubuntu_version|lower == 'bionic' %}9.6{% else %}9.5{% endif %}"
   websocketd_version: 0.3.0
   websocketd_filename: "websocketd-{{ websocketd_version }}-linux_{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}.zip"
-  angular_build_command: "ng build {% if (evergreen_major_version|int == 3 and evergreen_minor_version|int < 9) %}--prod{% else %}--configuration=production{% endif %}"
+  angular_build_command: "npx ng build {% if (evergreen_major_version|int == 3 and evergreen_minor_version|int < 9) %}--prod{% else %}--configuration=production{% endif %}"
   evergreen_server_filename: Evergreen-ILS-{{evergreen_major_version}}.{{evergreen_minor_version}}.{{evergreen_bug_version}}
 
 # The latest version of OpenSRF seems to work with all versions of Evergreen.


### PR DESCRIPTION
See https://bugs.launchpad.net/evergreen/+bug/2096711 -- this should be a backwards compatible change.