### PR TITLE
Add ARM64 (Apple Silicon) support for container builds

### DIFF
--- a/generic-dockerhub/vars.yml
+++ b/generic-dockerhub/vars.yml
@@ -63,7 +63,7 @@
   use_custom_opensrf_xml: no
 # If you want to enable Anubis, provide the download path to the deb file
 # if blank, it will not be enabled for the install
-  anubis_deb_package: https://github.com/TecharoHQ/anubis/releases/download/v1.19.1/anubis_1.19.1_amd64.deb
+  anubis_deb_package: "https://github.com/TecharoHQ/anubis/releases/download/v1.19.1/anubis_1.19.1_{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}.deb"
 # If you're setting up this container behind a load balancer, you'll need to provide
 # a path to a centrally located txt file containing the pre-created key. Generate one like this:
 # openssl rand -hex 32 > /mnt/evergreen/tmp/anubiskey.txt

--- a/generic-tarball/vars.yml
+++ b/generic-tarball/vars.yml
@@ -64,7 +64,7 @@
   use_custom_opensrf_xml: no
 # If you want to enable Anubis, provide the download path to the deb file
 # if blank, it will not be enabled for the install
-  anubis_deb_package: https://github.com/TecharoHQ/anubis/releases/download/v1.19.1/anubis_1.19.1_amd64.deb
+  anubis_deb_package: "https://github.com/TecharoHQ/anubis/releases/download/v1.19.1/anubis_1.19.1_{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}.deb"
 # If you're setting up this container behind a load balancer, you'll need to provide
 # a path to a centrally located txt file containing the pre-created key. Generate one like this:
 # openssl rand -hex 32 > /mnt/evergreen/tmp/anubiskey.txt


### PR DESCRIPTION
## Summary

- Fix hardcoded `amd64` Anubis deb package URL to use `ansible_architecture` detection (same pattern already used for `websocketd_filename`)
- Enables native ARM64/aarch64 container builds on Apple Silicon Macs, AWS Graviton, and other ARM64 platforms

## Changes

The `anubis_deb_package` URL in `generic-dockerhub/vars.yml` and `generic-tarball/vars.yml` was hardcoded to `anubis_1.19.1_amd64.deb`. This PR makes it architecture-aware:

```yaml
# Before
anubis_deb_package: https://...anubis_1.19.1_amd64.deb

# After  
anubis_deb_package: "https://...anubis_1.19.1_{% if ansible_architecture == 'aarch64' %}arm64{% else %}amd64{% endif %}.deb"
```

This matches the existing pattern used for `websocketd_filename` on line 22 of the same files. Anubis provides official arm64 .deb packages, so no upstream changes are needed.

## Motivation

The Evergreen ILS Docker image (`mobiusoffice/evergreen-ils`) is currently only available for `linux/amd64`. Running it on Apple Silicon requires QEMU emulation, which is significantly slower. With this fix, the image can be built natively on ARM64 — everything else in the Dockerfile and Ansible playbooks is already architecture-independent.

## Testing

- Verified Anubis arm64 .deb exists at the generated URL
- Building natively on Apple Silicon M-series (macOS arm64 with podman)
- No changes to amd64 behavior (the Jinja2 conditional defaults to amd64)

## Follow-up suggestion

Consider publishing multi-architecture images to Docker Hub using `docker buildx` or `podman manifest` so that `mobiusoffice/evergreen-ils` tags automatically serve the correct architecture. Happy to help with a CI workflow for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)