### PR TITLE
Apply OS security patches during image build

### DIFF
--- a/generic-dockerhub-dev/Dockerfile
+++ b/generic-dockerhub-dev/Dockerfile
@@ -26,6 +26,9 @@ RUN cd /egconfigs && ansible-playbook test_vars.yml -v
 RUN apt-get -y install syslog-ng-core sendmail mailutils sendmail-bin logrotate ssh net-tools iputils-ping sudo nano make autoconf libtool git mlocate git-core ntp cron screen rsync curl vim
 RUN if [ $os != "xenial"] ; then dpkg-reconfigure --frontend noninteractive tzdata ; fi
 
+# Apply security patches to base OS packages
+RUN apt-get update -qq && apt-get -y --no-install-recommends dist-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /mnt/evergreen
 
 # Run dockerbase script

--- a/generic-dockerhub/Dockerfile
+++ b/generic-dockerhub/Dockerfile
@@ -26,6 +26,9 @@ RUN cd /egconfigs && ansible-playbook test_vars.yml -v
 RUN apt-get -qq -y install syslog-ng-core sendmail mailutils sendmail-bin logrotate ssh net-tools iputils-ping sudo nano make autoconf libtool git mlocate git-core ntp cron screen rsync curl vim
 RUN if [ $os != "xenial"] ; then dpkg-reconfigure --frontend noninteractive tzdata ; fi
 
+# Apply security patches to base OS packages
+RUN apt-get update -qq && apt-get -y --no-install-recommends dist-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /mnt/evergreen
 
 # Run dockerbase script

--- a/generic-tarball/Dockerfile
+++ b/generic-tarball/Dockerfile
@@ -26,6 +26,9 @@ RUN cd /egconfigs && ansible-playbook test_vars.yml -v
 RUN apt-get -qq -y install syslog-ng-core sendmail mailutils sendmail-bin logrotate ssh net-tools iputils-ping sudo nano make autoconf libtool git mlocate git-core ntp cron screen rsync curl vim
 RUN if [ $os != "xenial"] ; then dpkg-reconfigure --frontend noninteractive tzdata ; fi
 
+# Apply security patches to base OS packages
+RUN apt-get update -qq && apt-get -y --no-install-recommends dist-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /mnt/evergreen
 
 # Run dockerbase script


### PR DESCRIPTION
## Summary
- Add `apt-get dist-upgrade` step to all three Dockerfiles (generic-dockerhub-dev, generic-dockerhub, generic-tarball)
- Placed after package installation, before the Evergreen build
- Ensures base OS packages (Apache, OpenSSL, etc.) receive security patches on each rebuild
- Uses `dist-upgrade` to handle dependency changes in security updates
- Cleans apt cache afterward to minimize image size

## Test plan
- [ ] Build generic-dockerhub-dev image and verify dist-upgrade runs
- [ ] Verify Evergreen install playbook still succeeds after upgrade
- [ ] Compare image size before/after (should be similar due to apt-get clean)