### PR TITLE
[dev container] Fix perl live test running

### DIFF
--- a/generic-dockerhub-dev/run_tests.yml
+++ b/generic-dockerhub-dev/run_tests.yml
@@ -119,6 +119,8 @@
     shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/perlmods && make livecheck
     ignore_errors: true
     tags: perl
+    environment:
+      PATH: "{{ ansible_env.PATH }}:{{openils_path}}/bin"
   - name: Test | Run C unit tests
     become: true
     shell: cd /home/opensrf/repos/Evergreen/Open-ILS/src/c-apps && make check


### PR DESCRIPTION
Before this commit, running `ansible-playbook /egconfigs/run_tests.yml -t perl`, you get a nasty failure in the task "Test | Run Perl live tests", looking something like this:

```
# Test patron loader script", "Can't exec \"patron_loader.pl\": No such file or directory at live_t/38-patron-loader.t line 75.
#   Failed test 'runs without error'
#   at live_t/38-patron-loader.t line 76.
#   Failed test 'Added 2 patrons'
#   at live_t/38-patron-loader.t line 79.
#          got: '0'"
#     expected: '2'"
#   Failed test 'Added usrname from CSV'
#   at live_t/38-patron-loader.t line 28.
# Looks like you planned 14 tests but ran 1.
```

We just don't have /openils/bin in the path for that step.

There are still other tasks/tags that fail, but getting there!