### PR TITLE
[dev] Move angular unit test chrome opt-out to the run_tests playbook

### DIFF
--- a/generic-dockerhub-dev/evergreen_restart_services.yml
+++ b/generic-dockerhub-dev/evergreen_restart_services.yml
@@ -243,14 +243,6 @@
     shell: cd /home/opensrf/repos/Evergreen-build/Open-ILS/web/js/ui/default/staff/ && npm run build-prod ; rsync -L -a --no-owner --no-perms --size-only /home/opensrf/repos/Evergreen-build/Open-ILS/web/js/ui/default/staff/ /home/opensrf/repos/Evergreen/Open-ILS/web/js/ui/default/staff
     when: evergreen_major_version|int > 2 and evergreen_minor_version|int > 0
 
-  - name: Opt out of Chrome eg2 testing on EG version 3.4 and above
-    lineinfile:
-      dest: /home/opensrf/repos/Evergreen-build/Open-ILS/src/eg2/karma.conf.js
-      state: present
-      regexp: ChromeHeadless
-      line: "    browsers: ['FirefoxHeadless'],"
-    when: evergreen_major_version|int > 2 and evergreen_minor_version|int > 3
-
   - name: Setting up eg2 for EG version 3.2 and above (on local build copy)
     become: true
     ignore_errors: yes

--- a/generic-dockerhub-dev/install_evergreen.yml
+++ b/generic-dockerhub-dev/install_evergreen.yml
@@ -402,14 +402,6 @@
     shell: cd /home/opensrf/repos/Evergreen/Open-ILS/web/js/ui/default/staff/ && yes | npm run build-prod
     when: evergreen_major_version|int > 2 and evergreen_minor_version|int > 0
 
-  - name: Opt out of Chrome eg2 testing on EG version 3.4 and above
-    lineinfile:
-      dest: /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/karma.conf.js
-      state: present
-      regexp: ChromeHeadless
-      line: "    browsers: ['FirefoxHeadless'],"
-    when: evergreen_major_version|int > 2 and evergreen_minor_version|int > 3
-
   - name: Add locale picker to Angular client
     lineinfile:
       dest: /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/src/environments/{{item}}

--- a/generic-dockerhub-dev/run_tests.yml
+++ b/generic-dockerhub-dev/run_tests.yml
@@ -38,6 +38,16 @@
       src: /usr/bin/firefox-nightly
       dest: /usr/bin/firefox
     tags: angularjs,angular,angular-unit,angular-e2e,opac
+  - name: Setup | Rsync eg2 to the build directory
+    shell: rsync -L -a --delete --no-owner --no-perms --size-only --exclude "node_modules" /home/opensrf/repos/Evergreen/Open-ILS/src/eg2/ /home/opensrf/repos/Evergreen-build/Open-ILS/src/eg2
+    tags: angular,angular-unit
+  - name: Setup | Opt out of Chrome eg2 testing
+    lineinfile:
+      dest: /home/opensrf/repos/Evergreen-build/Open-ILS/src/eg2/karma.conf.js
+      state: present
+      regexp: ChromeHeadless
+      line: "    browsers: ['FirefoxHeadless'],"
+    tags: angular,angular-unit
   - name: Setup | Give evergreen user access to opensrf directories
     user:
       name: evergreen


### PR DESCRIPTION
Before this commit, both install_evergreen.yml and evergreen_restart_services.yml attempted to configure Angular unit tests to run on Firefox only, rather than Firefox and Chrome (since Chrome and Chromium are difficult to set up in a docker container).  However, this configuration got overwritten anytime the eg_rebuild_angular routine ran, leading to odd output when running tests: ansible would report failure in red (since Chrome was missing) but also say that all tests passed (because they all passed on Firefox).

This commit removes the configuration attempts from install_evergreen.yml and evergreen_restart_services.yml, and just does it when we run the tests.